### PR TITLE
Fixed Byte Conversion bugs that would corrupt UInt, ULong, and Long Message Fields

### DIFF
--- a/dependencyLibs/Mavlink/src/com/MAVLink/Messages/MAVLinkPayload.java
+++ b/dependencyLibs/Mavlink/src/com/MAVLink/Messages/MAVLinkPayload.java
@@ -87,24 +87,24 @@ public class MAVLinkPayload {
 
     public long getUnsignedInt(){
         long result = 0;
-        result |= (payload.get(index + 3) & 0xFFFFL) << 24;
-        result |= (payload.get(index + 2) & 0xFFFFL) << 16;
-        result |= (payload.get(index + 1) & 0xFFFFL) << 8;
-        result |= (payload.get(index + 0) & 0xFFFFL);
+        result |= (payload.get(index + 3) & 0xFFL) << 24;
+        result |= (payload.get(index + 2) & 0xFFL) << 16;
+        result |= (payload.get(index + 1) & 0xFFL) << 8;
+        result |= (payload.get(index + 0) & 0xFFL);
         index += 4;
         return result;
     }
 
     public long getLong() {
         long result = 0;
-        result |= (payload.get(index + 7) & 0xFFFFL) << 56;
-        result |= (payload.get(index + 6) & 0xFFFFL) << 48;
-        result |= (payload.get(index + 5) & 0xFFFFL) << 40;
-        result |= (payload.get(index + 4) & 0xFFFFL) << 32;
-        result |= (payload.get(index + 3) & 0xFFFFL) << 24;
-        result |= (payload.get(index + 2) & 0xFFFFL) << 16;
-        result |= (payload.get(index + 1) & 0xFFFFL) << 8;
-        result |= (payload.get(index + 0) & 0xFFFFL);
+        result |= (payload.get(index + 7) & 0xFFL) << 56;
+        result |= (payload.get(index + 6) & 0xFFL) << 48;
+        result |= (payload.get(index + 5) & 0xFFL) << 40;
+        result |= (payload.get(index + 4) & 0xFFL) << 32;
+        result |= (payload.get(index + 3) & 0xFFL) << 24;
+        result |= (payload.get(index + 2) & 0xFFL) << 16;
+        result |= (payload.get(index + 1) & 0xFFL) << 8;
+        result |= (payload.get(index + 0) & 0xFFL);
         index += 8;
         return result;
     }
@@ -115,14 +115,14 @@ public class MAVLinkPayload {
     
     public long getLongReverse() {
         long result = 0;
-        result |= (payload.get(index + 0) & 0xFFFFL) << 56;
-        result |= (payload.get(index + 1) & 0xFFFFL) << 48;
-        result |= (payload.get(index + 2) & 0xFFFFL) << 40;
-        result |= (payload.get(index + 3) & 0xFFFFL) << 32;
-        result |= (payload.get(index + 4) & 0xFFFFL) << 24;
-        result |= (payload.get(index + 5) & 0xFFFFL) << 16;
-        result |= (payload.get(index + 6) & 0xFFFFL) << 8;
-        result |= (payload.get(index + 7) & 0xFFFFL);
+        result |= (payload.get(index + 0) & 0xFFL) << 56;
+        result |= (payload.get(index + 1) & 0xFFL) << 48;
+        result |= (payload.get(index + 2) & 0xFFL) << 40;
+        result |= (payload.get(index + 3) & 0xFFL) << 32;
+        result |= (payload.get(index + 4) & 0xFFL) << 24;
+        result |= (payload.get(index + 5) & 0xFFL) << 16;
+        result |= (payload.get(index + 6) & 0xFFL) << 8;
+        result |= (payload.get(index + 7) & 0xFFL);
         index += 8;
         return result;
     }


### PR DESCRIPTION
The mask used to get the byte data before bitshifting it into the correct location should be 0xFFL instead of 0xFFFFL.  

In the latter case, a negative byte (>127) would result in the bitshifted value being 2's complemented, which would cause the next or to overwrite the just written bit with FF.  In my case, this was causing the library to parse the timestamps to the incorrect value, even though the bytes received over the serial port were correct.

Ex.
Byte Value: 0xC8
0xC8 & 0xFFFFL = 0xFFC8 (which is then bitshifted, causing 0xFF to overwrite the index+1 location)
