### PR TITLE
Fixes #462: Allow SiK Radio Messages to pass through to vehicle.

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPilot.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPilot.java
@@ -390,10 +390,11 @@ public abstract class ArduPilot extends GenericMavLinkDrone {
             return;
         }
 
+        // Filter Components IDs to be specifically the IDs that can be processed
         int compId = message.compid;
         if (compId != AUTOPILOT_COMPONENT_ID
                 && compId != ARTOO_COMPONENT_ID
-                && !(message.sysid == SiK_RADIO_FIXED_SYSID && compId == SiK_RADIO_FIXED_COMPID) ){
+                && compId != SiK_RADIO_FIXED_COMPID ){
             return;
         }
 

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPilot.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPilot.java
@@ -74,7 +74,6 @@ import timber.log.Timber;
 public abstract class ArduPilot extends GenericMavLinkDrone {
     public static final int AUTOPILOT_COMPONENT_ID = 1;
     public static final int ARTOO_COMPONENT_ID = 0;
-    public static final int TELEMETRY_RADIO_COMPONENT_ID = 68;
 
     public static final String FIRMWARE_VERSION_NUMBER_REGEX = "\\d+(\\.\\d{1,2})?";
 
@@ -386,7 +385,7 @@ public abstract class ArduPilot extends GenericMavLinkDrone {
     @Override
     public void onMavLinkMessageReceived(MAVLinkMessage message) {
 
-        if (message.sysid != this.getSysid()) {
+        if ((message.sysid != this.getSysid()) && !isMavLinkMessageException(message)) {
             // Reject Messages that are not for the system id
             return;
         }
@@ -394,7 +393,7 @@ public abstract class ArduPilot extends GenericMavLinkDrone {
         int compId = message.compid;
         if (compId != AUTOPILOT_COMPONENT_ID
                 && compId != ARTOO_COMPONENT_ID
-                && compId != TELEMETRY_RADIO_COMPONENT_ID) {
+                && !(message.sysid == SiK_RADIO_FIXED_SYSID && compId == SiK_RADIO_FIXED_COMPID) ){
             return;
         }
 

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
@@ -83,6 +83,9 @@ import org.droidplanner.services.android.impl.utils.video.VideoManager;
  */
 public class GenericMavLinkDrone implements MavLinkDrone {
 
+    public static final int SiK_RADIO_FIXED_SYSID = 0x33;  // '3' 0x33 51
+    public static final int SiK_RADIO_FIXED_COMPID = 0x44; // 'D' 0x44 68
+
     private final DataLink.DataLinkProvider<MAVLinkMessage> mavClient;
 
     protected final VideoManager videoMgr;
@@ -572,11 +575,21 @@ public class GenericMavLinkDrone implements MavLinkDrone {
         heartbeat.onHeartbeat(msg);
     }
 
+    // Check if message should be allowed to pass even if sysid/compid mismatch
+    protected boolean isMavLinkMessageException(MAVLinkMessage message){
+
+        // Allows SiK Radio Messages through. // TODO Make it a configurable setting
+        if (message.sysid == SiK_RADIO_FIXED_SYSID && message.compid == SiK_RADIO_FIXED_COMPID) {
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public void onMavLinkMessageReceived(MAVLinkMessage message) {
 
-        if (message.sysid != this.getSysid()) {
-            // Reject Messages that are not for the system id
+        if ( (message.sysid != this.getSysid()) && !isMavLinkMessageException(message) ) {
+            // Reject Messages that are not for this drones system id
             return;
         }
 

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
@@ -83,7 +83,9 @@ import org.droidplanner.services.android.impl.utils.video.VideoManager;
  */
 public class GenericMavLinkDrone implements MavLinkDrone {
 
+    /** Fixed SYSTEM_ID - {@value}, for SiK Telemetry Radio (aka 3DR Telemetry Radio) .*/
     public static final int SiK_RADIO_FIXED_SYSID = 0x33;  // '3' 0x33 51
+    /** Fixed COMPONENT_ID - {@value}, for SiK Telemetry Radio (aka 3DR Telemetry Radio) .*/
     public static final int SiK_RADIO_FIXED_COMPID = 0x44; // 'D' 0x44 68
 
     private final DataLink.DataLinkProvider<MAVLinkMessage> mavClient;
@@ -589,7 +591,7 @@ public class GenericMavLinkDrone implements MavLinkDrone {
     public void onMavLinkMessageReceived(MAVLinkMessage message) {
 
         if ( (message.sysid != this.getSysid()) && !isMavLinkMessageException(message) ) {
-            // Reject Messages that are not for this drones system id
+            // Reject messages that are not for this drone's system id
             return;
         }
 


### PR DESCRIPTION
The allows message throughs that have the sys id = '3' and the comp id = 'D'. But from testing I am still not seeing he RSSI showing in the menu. (even if I remove packet filtering all together)

I need to look more into why that is. (it could be my testing as I seldom use the Radio, but use a WiFi link) It maybe that HB message are not being sent from tower as they trigger the RSSI packet to start sending AFAIU.

Feel free to test and verify this works.