### PR TITLE
ArduPlane: get airspeed from msg_vfr_hud instead of global_position_int

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPlane.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/apm/ArduPlane.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.MAVLink.Messages.MAVLinkMessage;
-import com.MAVLink.common.msg_global_position_int;
-import com.MAVLink.common.msg_vfr_hud;
 import com.MAVLink.enums.MAV_TYPE;
 import com.github.zafarkhaja.semver.Version;
 import com.o3dr.android.client.apis.CapabilityApi;
@@ -39,32 +37,6 @@ public class ArduPlane extends ArduPilot {
     @Override
     public FirmwareType getFirmwareType() {
         return FirmwareType.ARDU_PLANE;
-    }
-
-    @Override
-    protected void processVfrHud(msg_vfr_hud vfrHud){
-        //Nothing to do. Plane used GLOBAL_POSITION_INT to set altitude and speeds unlike copter
-    }
-
-    /**
-     * Used to update the vehicle location, and altitude.
-     * @param gpi
-     */
-    @Override
-    protected void processGlobalPositionInt(msg_global_position_int gpi){
-        if(gpi == null)
-            return;
-
-        super.processGlobalPositionInt(gpi);
-
-        final double relativeAlt = gpi.relative_alt / 1000.0;
-
-        final double groundSpeedX = gpi.vx / 100.0;
-        final double groundSpeedY = gpi.vy / 100.0;
-        final double groundSpeed = Math.sqrt(Math.pow(groundSpeedX, 2) + Math.pow(groundSpeedY, 2));
-
-        final double climbRate = gpi.vz / 100.0;
-        setAltitudeGroundAndAirSpeeds(relativeAlt, groundSpeed, groundSpeed, climbRate);
     }
 
     @Override


### PR DESCRIPTION
Is fix to get true values from msg_vfr_hub.
Actually is get from global_position_int and air speed is this same what ground speed.

See 67 line code in ArduPlane class.