### PR TITLE
Created a new release version 3.1.0

### DIFF
--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.getkeepsafe.dexcount'
 
 ext {
     VERSION_MAJOR = 3
-    VERSION_MINOR = 0
-    VERSION_PATCH = 2
+    VERSION_MINOR = 1
+    VERSION_PATCH = 0
     VERSION_SUFFIX = "release"
 
     PUBLISH_ARTIFACT_ID = 'dronekit-android'

--- a/ClientLib/src/main/res/values/version.xml
+++ b/ClientLib/src/main/res/values/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="core_lib_version">30200</integer>
+    <integer name="core_lib_version">31000</integer>
 </resources>


### PR DESCRIPTION
Upped the minor version number as the message definitions hand't changed in 2 years so this is a big difference.
And ignore my branch version number - I got ahead of myself.  The commit itself is correct i.e. 3.1.0.