### PR TITLE
Removing unused package filter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ android:
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository
-    - extra-android-support
 
 before_script:
     - export GRADLE_OPTS="-XX:MaxPermSize=2048m -Xmx1536m"


### PR DESCRIPTION
I noticed in the travis output the following
Error: Ignoring unknown package filter 'extra-android-support'
so its obviously not being used so I have removed it.