### PR TITLE
Remove unnecessary permissionWatchdog

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/communication/connection/usb/UsbCDCConnection.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/communication/connection/usb/UsbCDCConnection.java
@@ -126,8 +126,8 @@ class UsbCDCConnection extends UsbConnection.UsbConnectionImpl {
         } else {
             removeWatchdog();
 
-            scheduler = Executors.newSingleThreadScheduledExecutor();
-            scheduler.schedule(permissionWatchdog, 15, TimeUnit.SECONDS);
+            //scheduler = Executors.newSingleThreadScheduledExecutor();
+            //scheduler.schedule(permissionWatchdog, 15, TimeUnit.SECONDS);
             Log.d(TAG, "Requesting permission to access usb device " + device.getDeviceName());
             manager.requestPermission(device, usbPermissionIntent);
         }


### PR DESCRIPTION
'permissionWatchdog' will lead to auto disconnect after 15 second if device requested permission. It is not necessary!